### PR TITLE
Require cl-lib instead of cl

### DIFF
--- a/rotate.el
+++ b/rotate.el
@@ -23,7 +23,7 @@
 ;; Boston, MA 02110-1301, USA.
 
 ;;; Code:
-(eval-when-compile (require 'cl))
+(eval-when-compile (require 'cl-lib))
 
 (defvar rotate-count 0)
 


### PR DESCRIPTION
cl is deprecated since Emacs 27. Use cl-lib instead to avoid warnings.